### PR TITLE
update lastEvent for event match "No task claimed"

### DIFF
--- a/server.js
+++ b/server.js
@@ -396,7 +396,31 @@ db.once('open', function() {
           : {};
       switch (event.program.toLowerCase()) {
         case 'generic-worker':
-          if (event.message.match(/Running task https/i)) {
+          if (event.message.match(/No task claimed/i)) {
+            var task = {
+              id: event.message.split('#')[1].split('/')[0],
+              started: new Date(event.received_at)
+            };
+            Minion.findOneAndUpdate(
+              {
+                _id: id
+              },
+              {
+                instanceId: hostname,
+                workerType: workerType,
+                dataCenter: dataCenter,
+                ipAddress: event.source_ip,
+                lastEvent: (new Date())
+              },
+              { upsert: true },
+              function(error, model) {
+                console.log(workerType + ' ' + hostname + ' - idle');
+                if (error) {
+                  return console.error(error);
+                }
+              }
+            );
+          } else if (event.message.match(/Running task https/i)) {
             var task = {
               id: event.message.split('#')[1].split('/')[0],
               started: new Date(event.received_at)

--- a/server.js
+++ b/server.js
@@ -397,10 +397,6 @@ db.once('open', function() {
       switch (event.program.toLowerCase()) {
         case 'generic-worker':
           if (event.message.match(/No task claimed/i)) {
-            var task = {
-              id: event.message.split('#')[1].split('/')[0],
-              started: new Date(event.received_at)
-            };
             Minion.findOneAndUpdate(
               {
                 _id: id
@@ -410,7 +406,7 @@ db.once('open', function() {
                 workerType: workerType,
                 dataCenter: dataCenter,
                 ipAddress: event.source_ip,
-                lastEvent: (new Date())
+                lastEvent: (new Date((new Date()).toISOString()))
               },
               { upsert: true },
               function(error, model) {


### PR DESCRIPTION
I updated the OSX "routine events" search to be:
>(program:sudo reboot) OR (program:generic-worker "No task claimed" OR "Running task https://tools.taskcluster.net/task-inspector/#" OR "finished successfully" OR "ERROR(s) encountered")

It looks like the lastEvent record is used to show when workers have failed (when lastRecord is old for a worker).