### PR TITLE
set created time if insert of new minion

### DIFF
--- a/server.js
+++ b/server.js
@@ -408,6 +408,7 @@ db.once('open', function() {
                 ipAddress: event.source_ip,
                 lastEvent: (new Date((new Date()).toISOString()))
               },
+              { $setOnInsert: { created: new Date(event.received_at) } },
               { upsert: true },
               function(error, model) {
                 console.log(workerType + ' ' + hostname + ' - idle');

--- a/server.js
+++ b/server.js
@@ -415,6 +415,7 @@ db.once('open', function() {
                   tasks: task
                 }
               },
+              { $setOnInsert: { created: new Date(event.received_at) } },
               { upsert: true },
               function(error, model) {
                 console.log(workerType + ' ' + hostname + ' - task started: ' + task.id);
@@ -583,6 +584,7 @@ db.once('open', function() {
                   restarts: shutdown
                 }
               },
+              { $setOnInsert: { created: new Date(event.received_at) } },
               {
                 upsert: true
               },


### PR DESCRIPTION
For hardware, we do not record the created time because there is no rename event. Instead, we can record created as the first time we see an event for that worker.

This will allow the ui to show the uptime for the hardware workers as (first-event until (terminated or now)). For hardware, it might be more useful to see uptime since last reboot, but we'd need to add special events for that to not reset created datetime for vms also.

using the $setOnInsert option in the mongo collection update action:
https://docs.mongodb.com/manual/reference/operator/update/setOnInsert/#op._S_setOnInsert