### PR TITLE
set created for osx deploy

### DIFF
--- a/server.js
+++ b/server.js
@@ -549,7 +549,7 @@ db.once('open', function() {
               dataCenter: dataCenter,
               ipAddress: event.source_ip,
               created: new Date(event.received_at),
-              lastEvent: new Date()
+              lastEvent: (new Date((new Date()).toISOString()))
             };
             Minion.findOneAndUpdate(
               {

--- a/server.js
+++ b/server.js
@@ -535,6 +535,33 @@ db.once('open', function() {
             );
           }
           break;
+        case 'DeployStudio':
+          if (event.message.match(/Running autostarted workflow:/)) {
+            var instance = {
+              instanceId: hostname,
+              workerType: workerType,
+              dataCenter: dataCenter,
+              ipAddress: event.source_ip,
+              created: new Date(event.received_at),
+              lastEvent: new Date()
+            };
+            Minion.findOneAndUpdate(
+              {
+                _id: id,
+              },
+              instance,
+              {
+                upsert: true
+              },
+              function(error, model) {
+                console.log(workerType + ' ' + hostname + ' - reimaged: ' + new Date(event.received_at));
+                if (error) {
+                  return console.error(error);
+                }
+              }
+            );
+          }
+          break;
         case 'nxlog':
           if (event.message.match(/INFO nxlog-ce-[\.0-9]* started/i)) {
             Minion.update(


### PR DESCRIPTION
This will set the created datetime for OSX workers when they are reimaged. Then the "uptime" means the time for that imaged instance, much like the uptime for aws vms.

Logs for deploystudio reimaging of macs look like:
```
Nov 09 15:23:33 t-yosemite-r7-272.test.releng.mdc1.mozilla.com DeployStudio: Runtime.bin[389]: Operating System: Mac OS X Version 10.10.5 (Build 14F2109) 
Nov 09 15:23:38 t-yosemite-r7-272.test.releng.mdc1.mozilla.com DeployStudio: Runtime.bin[389]: Macintosh serial number: C07RJ0YPG1J2
Nov 09 15:23:38 t-yosemite-r7-272.test.releng.mdc1.mozilla.com DeployStudio: Runtime.bin[389]: Boot ROM version: MM71.88Z.0230.B00.1802091122
Nov 09 15:23:38 t-yosemite-r7-272.test.releng.mdc1.mozilla.com DeployStudio: Runtime.bin[389]: Running autostarted workflow: 'Restore yosemite-r7' (EE5AB2A3-3937-4096-B0F1-FC79F95A5AFD) 
```

So we can capture the workflow they went through and some other metadata.

Need to add event capture for:
> program:DeployStudio ("started workflow" OR "serial number" OR "Boot ROM version" OR "OS X Version")