### PR TITLE
created for linux hw: first puppet run

### DIFF
--- a/server.js
+++ b/server.js
@@ -510,6 +510,33 @@ db.once('open', function() {
             );
           }
           break;
+        case 'puppet-agent':
+          if (event.message.match("/Stage[main]/Users::Roller::Setup/Ssh::Userconfig[roller]/File[/home/roller/.ssh]/ensure")) {
+            var instance = {
+              instanceId: hostname,
+              workerType: workerType,
+              dataCenter: dataCenter,
+              ipAddress: event.source_ip,
+              created: new Date(event.received_at),
+              lastEvent: new Date()
+            };
+            Minion.findOneAndUpdate(
+              {
+                _id: id
+              },
+              instance,
+              {
+                upsert: true
+              },
+              function(error, model) {
+                console.log(workerType + ' ' + hostname + ' - reimaged: ' + shutdown.comment);
+                if (error) {
+                  return console.error(error);
+                }
+              }
+            );
+          }
+          break;
         case 'sudo':
           if (event.message.match(/reboot/i)) {
             var shutdown = {

--- a/server.js
+++ b/server.js
@@ -579,7 +579,7 @@ db.once('open', function() {
               dataCenter: dataCenter,
               ipAddress: event.source_ip,
               created: new Date(event.received_at),
-              lastEvent: new Date()
+              lastEvent: (new Date((new Date()).toISOString()))
             };
             Minion.findOneAndUpdate(
               {
@@ -590,7 +590,7 @@ db.once('open', function() {
                 upsert: true
               },
               function(error, model) {
-                console.log(workerType + ' ' + hostname + ' - reimaged: ' + shutdown.comment);
+                console.log(workerType + ' ' + hostname + ' - reimaged');
                 if (error) {
                   return console.error(error);
                 }


### PR DESCRIPTION
The roller user is set up on hardware during the first puppet run. So we can track from that for reimages of linux hardware. Not ideal, but the changes in the first puppet run are the only thing that we have logged on the worker machines to show it is reimaged.

We'll need to include the following search for our events on the linux machines:
> program:puppet-agent "/Stage[main]/Users::Roller::Setup/Ssh::Userconfig[roller]/File[/home/roller/.ssh]/ensure"
To give events like:
```
Nov 08 07:31:42 t-linux64-ms-240.test.releng.mdc1.mozilla.com puppet-agent: (/Stage[main]/Users::Roller::Setup/Ssh::Userconfig[roller]/File[/home/roller/.ssh]/ensure) created 
```